### PR TITLE
chore: run build in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,3 +11,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
ビルド時に `tsc` による型チェックがおこなわれるため