### PR TITLE
feat: adjust-connpass-event-count

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ const main = async () => {
   );
   const connpassEvents = await getConnpassEvents({
     keyword: getInput("CONNPASS_KEYWORD"),
+    count: 3,
   });
 
   await Promise.all(


### PR DESCRIPTION
Connpass APIは開催前のイベントを取得するオプションが存在せず、デフォルトのイベント取得件数10分が必ず取得されます。3つに制限することで文面上邪魔にならないようにする変更です