### PR TITLE
fix: FetchError invalid response json body

### DIFF
--- a/src/connpass.ts
+++ b/src/connpass.ts
@@ -4,8 +4,10 @@ const baseUrl = "https://connpass.com/api/v1";
 const options = {
   method: "get",
 } as const;
-const request = async <T>(api: string) =>
-  (await fetch(`${baseUrl}${api}`, options)).json() as Promise<T>;
+const request = async <T>(api: string) => {
+  const response = await fetch(`${baseUrl}${api}`, options);
+  return (await response.json()) as Promise<T>;
+};
 
 export type ConnpassEvents = {
   results_returned: number;

--- a/src/doorkeeper.ts
+++ b/src/doorkeeper.ts
@@ -5,8 +5,10 @@ const options = {
   method: "get",
   headers: { Authorization: `Bearer ${process.env.DOORKEEPER_TOKEN}` },
 } as const;
-const request = async <T>(api: string) =>
-  (await fetch(`${baseUrl}${api}`, options)).json() as Promise<T>;
+const request = async <T>(api: string) => {
+  const response = await fetch(`${baseUrl}${api}`, options);
+  return (await response.json()) as Promise<T>;
+};
 
 export type DoorkeeperEvent = {
   title: string;


### PR DESCRIPTION
関連: https://github.com/oss-gate/workshop/issues/1532

以下のようなエラーへの対処

```
Run oss-gate/issue-cleaner@v3
FetchError: invalid json response body at https://api.doorkeeper.jp/groups/oss-gate/events reason: Unexpected end of JSON input
    at /home/runner/work/_actions/oss-gate/issue-cleaner/v3/node_modules/node-fetch/lib/index.js:272:32
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async main (/home/runner/work/_actions/oss-gate/issue-cleaner/v3/lib/main.js:22:11) {
  message: 'invalid json response body at https://api.doorkeeper.jp/groups/oss-gate/events reason: Unexpected end of JSON input',
  type: 'invalid-json'
}
```

レスポンスボディの取得とJSONでのパースを
同じタイミングでおこなっているために
レスポンスボディの取得前にJSONでのパースが
おこなわれうることが原因